### PR TITLE
Fix typo: rename parameter evanscent to evanescent in S_parameters

### DIFF
--- a/torcwa/rcwa.py
+++ b/torcwa/rcwa.py
@@ -297,7 +297,7 @@ class rcwa:
 
         return eps_recover, mu_recover
     
-    def S_parameters(self,orders,*,direction='forward',port='transmission',polarization='xx',ref_order=[0,0],power_norm=True,evanscent=1e-3):
+    def S_parameters(self,orders,*,direction='forward',port='transmission',polarization='xx',ref_order=[0,0],power_norm=True,evanescent=1e-3,evanscent=None):
         '''
             Return S-parameters.
 
@@ -309,11 +309,16 @@ class rcwa:
             - polarization: set the input and output polarization of light ((output,input) xy-pol: 'xx' / 'yx' / 'xy' / 'yy' , ps-pol: 'pp' / 'sp' / 'ps' / 'ss' )
             - ref_order: set the reference for calculating S-parameters (Recommended shape: Nx2)
             - power_norm: if set as True, the absolute square of S-parameters are corresponds to the ratio of power
-            - evanescent: Criteria for judging the evanescent field. If power_norm=True and real(kz_norm)/imag(kz_norm) < evanscent, function returns 0 (default = 1e-3)
+            - evanescent: Criteria for judging the evanescent field. If power_norm=True and real(kz_norm)/imag(kz_norm) < evanescent, function returns 0 (default = 1e-3)
+            - evanscent: Deprecated alias for evanescent.
 
             Return
             - S-parameters (torch.Tensor)
         '''
+
+        if evanscent is not None:
+            warnings.warn('Parameter "evanscent" is deprecated. Use "evanescent" instead.',DeprecationWarning)
+            evanescent = evanscent
 
         orders = torch.as_tensor(orders,dtype=torch.int64,device=self._device).reshape([-1,2])
 
@@ -353,12 +358,12 @@ class rcwa:
             # power normalization factor
             if power_norm:
                 Kz_norm_dn_in_complex = torch.sqrt(self.eps_in*self.mu_in - self.Kx_norm_dn**2 - self.Ky_norm_dn**2)
-                is_evanescent_in = torch.abs(torch.real(Kz_norm_dn_in_complex) / torch.imag(Kz_norm_dn_in_complex)) < evanscent
+                is_evanescent_in = torch.abs(torch.real(Kz_norm_dn_in_complex) / torch.imag(Kz_norm_dn_in_complex)) < evanescent
                 Kz_norm_dn_in = torch.where(is_evanescent_in,torch.real(torch.zeros_like(Kz_norm_dn_in_complex)),torch.real(Kz_norm_dn_in_complex))
                 Kz_norm_dn_in = torch.hstack((Kz_norm_dn_in,Kz_norm_dn_in))
 
                 Kz_norm_dn_out_complex = torch.sqrt(self.eps_out*self.mu_out - self.Kx_norm_dn**2 - self.Ky_norm_dn**2)
-                is_evanescent_out = torch.abs(torch.real(Kz_norm_dn_out_complex) / torch.imag(Kz_norm_dn_out_complex)) < evanscent
+                is_evanescent_out = torch.abs(torch.real(Kz_norm_dn_out_complex) / torch.imag(Kz_norm_dn_out_complex)) < evanescent
                 Kz_norm_dn_out = torch.where(is_evanescent_out,torch.real(torch.zeros_like(Kz_norm_dn_out_complex)),torch.real(Kz_norm_dn_out_complex))
                 Kz_norm_dn_out = torch.hstack((Kz_norm_dn_out,Kz_norm_dn_out))
 
@@ -434,7 +439,7 @@ class rcwa:
             order_Kt_norm_dn = torch.sqrt(order_Kx_norm_dn**2 + order_Ky_norm_dn**2)
             order_Kz_norm_dn = order_sign*torch.abs(torch.real(torch.sqrt(order_k0_norm2 - order_Kx_norm_dn**2 - order_Ky_norm_dn**2)))
             order_Kz_norm_dn_complex = torch.sqrt(order_k0_norm2 - order_Kx_norm_dn**2 - order_Ky_norm_dn**2)
-            order_is_evanescent = torch.abs(torch.real(order_Kz_norm_dn_complex) / torch.imag(order_Kz_norm_dn_complex)) < evanscent
+            order_is_evanescent = torch.abs(torch.real(order_Kz_norm_dn_complex) / torch.imag(order_Kz_norm_dn_complex)) < evanescent
 
             order_inc_angle = torch.atan2(torch.real(order_Kt_norm_dn),order_Kz_norm_dn)
             order_azi_angle = torch.atan2(torch.real(order_Ky_norm_dn),torch.real(order_Kx_norm_dn))
@@ -444,7 +449,7 @@ class rcwa:
             ref_Kt_norm_dn = torch.sqrt(ref_Kx_norm_dn**2 + ref_Ky_norm_dn**2)
             ref_Kz_norm_dn = ref_sign*torch.abs(torch.real(torch.sqrt(ref_k0_norm2 - ref_Kx_norm_dn**2 - ref_Ky_norm_dn**2)))
             ref_Kz_norm_dn_complex = torch.sqrt(ref_k0_norm2 - ref_Kx_norm_dn**2 - ref_Ky_norm_dn**2)
-            ref_is_evanescent = torch.abs(torch.real(ref_Kz_norm_dn_complex) / torch.imag(ref_Kz_norm_dn_complex)) < evanscent
+            ref_is_evanescent = torch.abs(torch.real(ref_Kz_norm_dn_complex) / torch.imag(ref_Kz_norm_dn_complex)) < evanescent
 
             ref_inc_angle = torch.atan2(torch.real(ref_Kt_norm_dn),ref_Kz_norm_dn)
             ref_azi_angle = torch.atan2(torch.real(ref_Ky_norm_dn),torch.real(ref_Kx_norm_dn))
@@ -486,12 +491,12 @@ class rcwa:
 
             if power_norm:
                 Kz_norm_dn_in_complex = torch.sqrt(self.eps_in*self.mu_in - self.Kx_norm_dn**2 - self.Ky_norm_dn**2)
-                is_evanescent_in = torch.abs(torch.real(Kz_norm_dn_in_complex) / torch.imag(Kz_norm_dn_in_complex)) < evanscent
+                is_evanescent_in = torch.abs(torch.real(Kz_norm_dn_in_complex) / torch.imag(Kz_norm_dn_in_complex)) < evanescent
                 Kz_norm_dn_in = torch.where(is_evanescent_in,torch.real(torch.zeros_like(Kz_norm_dn_in_complex)),torch.real(Kz_norm_dn_in_complex))
                 Kz_norm_dn_in = torch.hstack((Kz_norm_dn_in,Kz_norm_dn_in))
 
                 Kz_norm_dn_out_complex = torch.sqrt(self.eps_out*self.mu_out - self.Kx_norm_dn**2 - self.Ky_norm_dn**2)
-                is_evanescent_out = torch.abs(torch.real(Kz_norm_dn_out_complex) / torch.imag(Kz_norm_dn_out_complex)) < evanscent
+                is_evanescent_out = torch.abs(torch.real(Kz_norm_dn_out_complex) / torch.imag(Kz_norm_dn_out_complex)) < evanescent
                 Kz_norm_dn_out = torch.where(is_evanescent_out,torch.abs(torch.real(Kz_norm_dn_out_complex)),torch.real(Kz_norm_dn_out_complex))
                 Kz_norm_dn_out = torch.hstack((Kz_norm_dn_out,Kz_norm_dn_out))
 


### PR DESCRIPTION
## Summary

- The parameter `evanscent` in `S_parameters()` was a misspelling of `evanescent`
- Renamed the parameter to `evanescent` for correctness
- Kept `evanscent` as a deprecated alias for backward compatibility, with a `DeprecationWarning` to guide existing users
- Fixed missing newline at end of file

## Changes

- `S_parameters(evanscent=1e-3)` → `S_parameters(evanescent=1e-3, evanscent=None)`
- Added `warnings.warn(DeprecationWarning)` when the old `evanscent` parameter is used
- Updated all 6 internal usages of `evanscent` → `evanescent`
- Updated docstring to reflect the corrected parameter name